### PR TITLE
Note which characters are missing from base58 alphabet

### DIFF
--- a/chapters/6.md
+++ b/chapters/6.md
@@ -43,6 +43,8 @@ Base58 Alphabet used in Monero:
 
 123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
 
+Note: Zero (0) along with the letters I (uppercase i), O (uppercase o), and l (lowercase L) are not present in this Base58 alphabet as they are the previously mentioned characters which might appear ambiguous.
+
 # The relationships between seeds, address and keys
 
 Before we get into the Monero deep, we have to introduce the concept of address generation.


### PR DESCRIPTION
This makes it more clear which characters are actually missing and highlights that these characters look similiar