### PR TITLE
ch6: superscript/subscript formatting

### DIFF
--- a/chapters/6.md
+++ b/chapters/6.md
@@ -52,11 +52,11 @@ In the context of clocks, staying up 5 hours past 11:00 PM could be represented 
 ## Elliptic Curve (Ed25519)
 Elliptic curves are defined as the set 2-dimensional (x, y) points that satisfy an equation:
 
-y^2=x^3+ax+b
+y<sup>2</sup>=x<sup>3</sup>+ax+b
 
 For example, with fixed coefficients a = 2 and b = 4, this equation becomes
 
-y^2=x^3+2x+3,
+y<sup>2</sup>=x<sup>3</sup>+2x+3,
 
 which is satisfied by many pairs of points such as: 
 
@@ -70,7 +70,7 @@ Monero uses a particular Twisted Edwards elliptic curve for cryptographic operat
 
 The ed25519 curve can be expressed algebraically as
 
--- x^2 + y^2 = 1 − (121665/121666) x^2 y^2
+-x<sup>2</sup> + y<sup>2</sup> = 1 − (121665/121666) x<sup>2</sup> y<sup>2</sup>
 
 Thinking back to our general elliptic curve equation, this Twisted Edwards is a special case using the parameters:
 
@@ -368,7 +368,7 @@ Chapter 3 described a situation where Leo sent George some Monero and in doing s
 
 The highly technical formula described in the CryptoNote whitepaper to produce this public output is `P = Hs(rA|i)G + B`. This means that when Leo wants to send Monero to George he generates a 256 bit pseudorandom scalar to be used as the transaction private key, r. Leo is the only person that will ever know this key, not even George. Leo then multiplies George's public view key, A, by his pseudorandom scalar and then concatenates the output index, i, to resulting point. 
 
-This data is then run through the `Hash to Scalar` function. This function takes the input data, hashes it using the Keccak-256 algorithm, then takes that resulting hash modulo 2^255 + 27742317777372353535851937790883648493, a prime order of the ed25519 basepoint. The ed25519 basepoint, G, is then multiplied by the scalar that is output from that function. Finally, Leo adds this point with George's public spend key, B, to produce the final output, P.
+This data is then run through the `Hash to Scalar` function. This function takes the input data, hashes it using the Keccak-256 algorithm, then takes that resulting hash modulo 2<sup>255</sup> + 27742317777372353535851937790883648493, a prime order of the ed25519 basepoint. The ed25519 basepoint, G, is then multiplied by the scalar that is output from that function. Finally, Leo adds this point with George's public spend key, B, to produce the final output, P.
 
 ### Receiving
 
@@ -382,7 +382,7 @@ One way to create off-chain likability is through address reuse. If George uses 
 
 ### Creating subaddresses
 
-So how are subaddresses actually made? Suppose that George has a pair of private keys, the private view key and the private spend key, (a,b) and a corrosponding pair of public keys (A,B) which is equal to (a,b)G where G is the generator point on the elliptic curve. First we must chose a number, `i`, called the index. Typically the first subaddress will be at index 1. The subaddress will also have a pair of private keys and a pair of public keys for each index of `i`, which we can then call (ci,di) and (Ci,Di). The formula to create a subaddress public spend key, `Di`, is `Hs(a|i)G+B`. This means that first the index, i, is concatenated to the main address private view key, a, and then passed through the `hash_to_scalar` function (note: in practice the reference client wallet also concatenates the string "SubAddr" to the data to be hashed as a common salt). Then the curve generator point, G, is multiplied by the resulting scalar and finally the main address public spend key is added to the resulting point through elliptic curve point addition. After this subaddress public spend key is generated, it is recorded for use later. To calculate the subaddress public view key, `Ci`, Di is multiplied by the main address private spend key (`Ci = a*Di`). Now that the subaddress public keys have been generated they can be encoded into a valid Monero address. Subaddresses are base58 encoded with a checksum just like normal addresses but the network byte is different. Mainnet subaddresses use the network byte 0x42 which makes every mainnet subaddress start with `8`.
+So how are subaddresses actually made? Suppose that George has a pair of private keys, the private view key and the private spend key, (a,b) and a corrosponding pair of public keys (A,B) which is equal to (a,b)G where G is the generator point on the elliptic curve. First we must chose a number, `i`, called the index. Typically the first subaddress will be at index 1. The subaddress will also have a pair of private keys and a pair of public keys for each index of `i`, which we can then call (c<sub>i</sub>,d<sub>i</sub>) and (C<sub>i</sub>,D<sub>i</sub>). The formula to create a subaddress public spend key, D<sub>i</sub>, is `Hs(a|i)G+B`. This means that first the index, `i`, is concatenated to the main address private view key, `a`, and then passed through the `hash_to_scalar` function (note: in practice the reference client wallet also concatenates the string "SubAddr" to the data to be hashed as a common salt). Then the curve generator point, `G`, is multiplied by the resulting scalar and finally the main address public spend key is added to the resulting point through elliptic curve point addition. After this subaddress public spend key is generated, it is recorded for use later. To calculate the subaddress public view key, C<sub>i</sub>, D<sub>i</sub> is multiplied by the main address private spend key (C<sub>i</sub> = a*D<sub>i</sub>). Now that the subaddress public keys have been generated they can be encoded into a valid Monero address. Subaddresses are base58 encoded with a checksum just like normal addresses but the network byte is different. Mainnet subaddresses use the network byte 0x42 which makes every mainnet subaddress start with `8`.
 
 ### Sending to a subaddress
 


### PR DESCRIPTION
use formatting like x<sup>3</sup> (` x<sup>3</sup>`) instead of x^3