### PR TITLE
fix typo in constant exponent + specify keccak-256 for calculating block ids

### DIFF
--- a/chapters/6.md
+++ b/chapters/6.md
@@ -368,7 +368,7 @@ Chapter 3 described a situation where Leo sent George some Monero and in doing s
 
 The highly technical formula described in the CryptoNote whitepaper to produce this public output is `P = Hs(rA|i)G + B`. This means that when Leo wants to send Monero to George he generates a 256 bit pseudorandom scalar to be used as the transaction private key, r. Leo is the only person that will ever know this key, not even George. Leo then multiplies George's public view key, A, by his pseudorandom scalar and then concatenates the output index, i, to resulting point. 
 
-This data is then run through the `Hash to Scalar` function. This function takes the input data, hashes it using the Keccak-256 algorithm, then takes that resulting hash modulo 2<sup>255</sup> + 27742317777372353535851937790883648493, a prime order of the ed25519 basepoint. The ed25519 basepoint, G, is then multiplied by the scalar that is output from that function. Finally, Leo adds this point with George's public spend key, B, to produce the final output, P.
+This data is then run through the `Hash to Scalar` function. This function takes the input data, hashes it using the Keccak-256 algorithm, then takes that resulting hash modulo 2<sup>252</sup> + 27742317777372353535851937790883648493, a prime order of the ed25519 basepoint. The ed25519 basepoint, G, is then multiplied by the scalar that is output from that function. Finally, Leo adds this point with George's public spend key, B, to produce the final output, P.
 
 ### Receiving
 

--- a/chapters/6.md
+++ b/chapters/6.md
@@ -272,7 +272,7 @@ Base transaction is followed by a list of transaction identifiers. A transaction
 
 ### Calculation of Block Identifier
 
-The identifier of a block is the result of hashing the following data with Keccak:
+The identifier of a block is the result of hashing the following data with Keccak-256:
 * size of block_header, Merkle root hash, and the number of transactions in bytes (varint)
 * block_header,
 * Merkle root hash,


### PR DESCRIPTION
`l` = 2<sup>252</sup> + 27742317777372353535851937790883648493 and specifically keccak-256 is used for calculating block ids as opposed to a more standard version of keccak