### PR TITLE
Remove 'Kovri' and 'monero-site' from the list of projects hosted on GitHub

### DIFF
--- a/chapters/5.md
+++ b/chapters/5.md
@@ -66,9 +66,7 @@ Many different repositories are hosted at the Monero Project GitHub [link: https
 * monero: the core of Monero network, written in C++ language
 * monero-GUI: Graphical User Interface for Monero, built with Qt library
 * monero-CLI: the CLI for Monero (included in the Monero-core repository)
-* monero-site: the website for Monero: https://getmonero.org
 * sekura: the community hardware wallet
-* kovri: The Kovri anonymizing router
 
 These projects are well-documented, so that you can become familiar with the code and make improvements! You can see that there are lots of different sub-projects with opportunities for you to contribute to Monero. Please visit one of the repositories, read through some of the open issues, and consider how you can leave your legacy in the Monero codebase.
 


### PR DESCRIPTION
Hey there, was giving a quick look to this chapter and found these two obsolete lines, will give a deeper review of the whole document when i have time.

Kovri is now a separated project hosted on GitLab and the monero-site repo is on repo.getmonero.org (also gitlab, but self hosted). I removed both from the list