### PR TITLE
Fix some markdown issues

### DIFF
--- a/chapters/3.md
+++ b/chapters/3.md
@@ -49,7 +49,7 @@ Prior to RingCT, Monero transactions were partitioned into specific denomination
 
 In keeping with Monero's policy of enforced privacy-by-default, RingCT became mandatory for all Monero transactions after September 2017. To spend any old pre-RingCT outputs, they must first be converted to RingCT outputs with masked amounts.
 
-### 3.2.1 Stealth (one-time) addresses
+### 3.2.2 Stealth (one-time) addresses
 
 All Monero transactions utilize stealth addresses to protect the privacy of the recipient. To avoid recording the recipient's wallet address onto the blockchain, each Monero transaction is instead sent to a unique disposable one-time address. The recipient can access funds sent to a stealth address, without exposing any links to their wallet's public addresses or other transactions.
 

--- a/chapters/4.md
+++ b/chapters/4.md
@@ -232,7 +232,7 @@ Hash functions are heavily utilized in many cryptocurrency security features. Cr
 
 This notion of an expanding append-only database with each group of entries cryptographically secured by hashes to the previous block is a key concept behind the blockchain revolution.
 
-## 4.5.2 Nonces (general concept)
+### 4.5.2 Nonces (general concept)
 
 The term nonce refers to a puzzle that is not inherently physically/mathematically meaningful. For example, consider the following “fill-in-the-blank” questions that a teacher might give their students:
 

--- a/chapters/4.md
+++ b/chapters/4.md
@@ -236,20 +236,20 @@ This notion of an expanding append-only database with each group of entries cryp
 
 The term nonce refers to a puzzle that is not inherently physically/mathematically meaningful. For example, consider the following “fill-in-the-blank” questions that a teacher might give their students:
 
-Puzzle A) The Esperanto word for "c___" inspired the name “Monero”
+Puzzle A) The Esperanto word for "c\_\_\_" inspired the name “Monero”
 	Acceptable answer: “coin”
-Puzzle B) 1 kilogram is equal to "_____" grams. 
+Puzzle B) 1 kilogram is equal to "\_\_\_\_" grams.
 	Acceptable answer: 1000
-Puzzle C) This 3-digit prime number "3___" does not repeat any digits
+Puzzle C) This 3-digit prime number "3\_\_\_" does not repeat any digits
 	Acceptable nonces: any of {307, 317, 347, 349, 359, etc…}
-Puzzle D) This 5-digit prime number "7___" does not repeat any digits 
+Puzzle D) This 5-digit prime number "7\_\_\_" does not repeat any digits
 	Acceptable nonces: any of {71263, 72169, 73609, 74869, etc…}
 
 Puzzle A and B are both meaningful, and each have one correct answer (A: “coin” B: “1000”) that the student will want to remember for future problems. Thus, these answers are not considered “nonces”.
 
 However, puzzles C and D are both “busy work” tasks that are hard to solve, and do not contribute insight to any real problem. There are multiple solutions that all satisfy the nonce requirement; for question C, the answer “359” is equally as valid as “307.” 
 
-A student that spends an hour testing various numbers to come up with the answer “359” for puzzle C has to start the search for a valid nonce from scratch upon encountering each variation on the puzzle, e.g. “This 3-digit prime number “6___” does not repeat any digits.”
+A student that spends an hour testing various numbers to come up with the answer “359” for puzzle C has to start the search for a valid nonce from scratch upon encountering each variation on the puzzle, e.g. “This 3-digit prime number “6\_\_\_” does not repeat any digits.”
 
 If you only had a pencil and paper (or even with a calculator), would you rather solve puzzle C or puzzle D? Probably puzzle C, since you're likely to find a valid 3-digit answer faster than a valid 5-digit answer. You can see how the difficulty of the problem can be arbitrarily adjusted by changing how many digits are required.
 

--- a/chapters/5.md
+++ b/chapters/5.md
@@ -196,14 +196,15 @@ When your wallet presents the 24-word seed, it adds a 25th word that functions a
 
 The private view key is derived by hashing the seed with Keccak-256, producing a second 256-bit integer, which is then sent to the function called sc_reduce32 to ensure that it is compatible with the elliptic curve. The seeds created by this method will always be valid scalars as they are sent to sc_reduce32 first. 
 
-5.3.2 Key derivation
-5.3.2.1 All keys
+### 5.3.2 Key derivation
+
+#### 5.3.2.1 All keys
 
 The Monero seed described above is actually your secret spend key, from which all other keys are derived. The secret view key is the reduced hash of your secret spend key, converted to a valid scalar for the ed25519 curve.
 
 These two private keys are multiplied by the generator point to yield the two public keys for your wallet (public spend and public view). This method for derivating keys is referred to as the deterministic method.
 
-5.3.2.2 View-only wallets
+#### 5.3.2.2 View-only wallets
 
 You can grant view-only access to a Monero account by setting up a wallet with your secret view key, but NOT the secret spend key. These view-only wallets can see all incoming transactions, but cannot spend moneroj or see outgoing transactions.
 
@@ -434,7 +435,7 @@ If you want to venture even further into the calculations behind these technolog
 
 By now you're familiar with the importance and utility of blockchains as distributed public ledgers. These blocks are structured and ordered into an immutable append-only database, secured by cryptographic tools that prevent any tampering or cheating. Monero's blockchain is unique and we'll discuss its technology and specifications in this section.
 
-#### 5.5.1 Lightning Memory Mapped Database
+### 5.5.1 Lightning Memory Mapped Database
 
 Monero uses the Lightning Memory Mapped Database (LMDB) system to store its blockchain. LMDB is a software library that provides a high-performance embedded transactional database in the form of a key-value store. This means that it is highly effective, and easy to search.
 

--- a/chapters/6.md
+++ b/chapters/6.md
@@ -104,11 +104,11 @@ Boost |	libunwind |	Doxygen
 OpenSSL |	liblzma |	Graphviz
 libzmq |	libreadline |	pcsclite
 
-### 6.3.4 Building instruction
+### 6.3.3 Building instruction
 
 Monero uses the CMake build system and a top-level makefile that invokes cmake commands, as needed. Once you've installed the dependences, change to the root of the source code directory and execute the make command to begin the build. The process may take up to an hour or two. Once the code has finished building, you can find the Monero binaries in the build folder. 
 
-### 6.3.5 Build troubleshooting
+### 6.3.4 Build troubleshooting
 
 If you encounter errors, the output will typically indicate exactly what went wrong. A few of the common bugs to troubleshoot include:
 
@@ -120,7 +120,7 @@ If you encounter errors, the output will typically indicate exactly what went wr
 
 You can (optionally) type make debug to compile a debugging build. There are many communities with information to help you with troubleshooting. Search engine queries with your build errors are likely to connect you with a solution or people that can help.
 
-### 6.3.6 Building Monero Graphical User Interface
+### 6.3.5 Building Monero Graphical User Interface
 
 The Monero graphical user interface (GUI) is built with C++ and Qt libraries. Both are necessary to successfully build the GUI. With the dependencies in place, you can clone and build the GUI with the commands:
 

--- a/chapters/7.md
+++ b/chapters/7.md
@@ -237,7 +237,7 @@ Should simply return:
 
 You can use RPC methods like this to develop your own personal client for your Monero wallet!
 
-## 7.4.2 Tutorial 2 - How to generate a pseudo-random address
+### 7.4.2 Tutorial 2 - How to generate a pseudo-random address
 
 In chapter 5, we introduced the concept of pseudo-random address generation. To augment the mathematical explanation, here is a python implementation for you to follow.
 


### PR DESCRIPTION
Fixes unescaped underscores of `4.md` and headers of `1.md` to `7.md`.  `8.md` also has a header issue (there's a jump from 5. to 8.), but it might still be in progress, so it's not touched.